### PR TITLE
Adding in the ability to pass frames, verbatim, through a fault injector

### DIFF
--- a/cmd/faultinjector/commands.go
+++ b/cmd/faultinjector/commands.go
@@ -27,7 +27,7 @@ func newRootCommand() *cobra.Command {
 	return rootCmd
 }
 
-func runCommand(ctx context.Context, cmd *cobra.Command, injector faultinjectors.MirrorCallback) error {
+func runFaultInjector(ctx context.Context, cmd *cobra.Command, injector faultinjectors.MirrorCallback) error {
 	port := 5671
 
 	addressFile, err := cmd.Flags().GetString(addressFileFlagName)
@@ -89,7 +89,7 @@ func newDetachAfterDelayCommand(ctx context.Context) *cobra.Command {
 				Description: *detachErrorDesc,
 			})
 
-			return runCommand(ctx, cmd, injector.Callback)
+			return runFaultInjector(ctx, cmd, injector.Callback)
 		},
 	}
 
@@ -113,7 +113,7 @@ func newDetachAfterTransferCommand(ctx context.Context) *cobra.Command {
 				Condition:   encoding.ErrCond(*detachErrorCond),
 				Description: *detachErrorDesc,
 			})
-			return runCommand(ctx, cmd, injector.Callback)
+			return runFaultInjector(ctx, cmd, injector.Callback)
 		},
 	}
 
@@ -132,7 +132,7 @@ func newSlowTransferFrames(ctx context.Context) *cobra.Command {
 		Short: "Slows down TRANSFER frames",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			injector := faultinjectors.NewSlowTransfersInjector(*delay)
-			return runCommand(ctx, cmd, injector.Callback)
+			return runFaultInjector(ctx, cmd, injector.Callback)
 		},
 	}
 
@@ -146,7 +146,7 @@ func newPassthroughCommand(ctx context.Context) *cobra.Command {
 		Use:   "passthrough",
 		Short: "Runs the fault injector but passes all frames through. Useful for troubleshooting.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runCommand(ctx, cmd, func(ctx context.Context, params faultinjectors.MirrorCallbackParams) ([]faultinjectors.MetaFrame, error) {
+			return runFaultInjector(ctx, cmd, func(ctx context.Context, params faultinjectors.MirrorCallbackParams) ([]faultinjectors.MetaFrame, error) {
 				return []faultinjectors.MetaFrame{{
 					Action: faultinjectors.MetaFrameActionPassthrough, Frame: params.Frame,
 				}}, nil

--- a/internal/faultinjectors/mirror_callback.go
+++ b/internal/faultinjectors/mirror_callback.go
@@ -44,7 +44,7 @@ func (mcp MirrorCallbackParams) Channel() uint16 {
 
 // Type is the BodyType of the underlying frame.
 func (mcp MirrorCallbackParams) Type() frames.BodyType {
-	return mcp.Frame.BodyType
+	return mcp.Frame.Body.Type()
 }
 
 // Address is the address from the ATTACH frame that corresponds to

--- a/internal/faultinjectors/slow_transfers_injector.go
+++ b/internal/faultinjectors/slow_transfers_injector.go
@@ -38,7 +38,7 @@ func (inj *SlowTransfersInjector) Callback(ctx context.Context, params MirrorCal
 	transferFrame, ok := params.Frame.Body.(*frames.PerformTransfer)
 
 	if !ok {
-		utils.Panicf("BodyType was %s, but the actual body type was %T", params.Frame.BodyType, params.Frame.Body)
+		utils.Panicf("BodyType was %s, but the actual body type was %T", params.Frame.Body.Type(), params.Frame.Body)
 	}
 
 	deliveryID := "<unspecified>"

--- a/internal/logging/frame_logger.go
+++ b/internal/logging/frame_logger.go
@@ -44,7 +44,7 @@ func (l *FrameLogger) AddFrame(out bool, fr *frames.Frame, metadata any) error {
 		Time:      time.Now(),
 		Direction: direction,
 		Frame:     fr,
-		FrameType: fr.BodyType,
+		FrameType: fr.Body.Type(),
 		Metadata:  metadata,
 	}
 

--- a/internal/logging/json_logger.go
+++ b/internal/logging/json_logger.go
@@ -111,7 +111,7 @@ func (l *JSONLogger) flush(out bool) error {
 				Time:      time.Now(),
 				Direction: direction,
 				Frame:     frame,
-				FrameType: frame.BodyType,
+				FrameType: frame.Body.Type(),
 			}
 
 			if l.sm != nil {

--- a/internal/proto/frames/bodies.go
+++ b/internal/proto/frames/bodies.go
@@ -365,6 +365,16 @@ func (e *EmptyFrame) Marshal(wr *buffer.Buffer) error {
 	return nil
 }
 
+type RawFrame struct{}
+
+func (r *RawFrame) frameBody()         {}
+func (r *RawFrame) Type() BodyType     { return BodyTypeRawFrame }
+func (r *RawFrame) GetHandle() *uint32 { return nil }
+
+func (r *RawFrame) Marshal(wr *buffer.Buffer) error {
+	return nil
+}
+
 /*
 <type name="open" class="composite" source="list" provides="frame">
     <descriptor name="amqp:open:list" code="0x00000000:0x00000010"/>

--- a/internal/proto/frames/buffer.go
+++ b/internal/proto/frames/buffer.go
@@ -65,10 +65,9 @@ func (fb *Buffer) Extract() (PreambleOrFrame, error) {
 		rawBuff = append(rawBuff, fb.buff[0:n]...)
 
 		amqpItem := &Frame{
-			Header:   *fb.currentHeader,
-			Body:     body,
-			BodyType: body.Type(),
-			raw:      rawBuff,
+			Header: *fb.currentHeader,
+			Body:   body,
+			raw:    rawBuff,
 		}
 
 		fb.buff = fb.buff[n:]

--- a/samples/sample_raw_fault_injector/README.md
+++ b/samples/sample_raw_fault_injector/README.md
@@ -1,0 +1,19 @@
+# Sample Raw Fault Injector
+
+This is a imple self-contained example of a fault injector. You can use this as a starting point for writing your own fault injector or to test out ideas.
+
+NOTE: you'll be editing this project, so some basic Go language knowledge is required.
+
+## Running
+
+### Launching the fault injector
+
+1. Install Go 1.24+.
+1. Clone this repo: `git clone https://github.com/richardpark-msft/amqpfaultinjector`
+1. Open a terminal: `cd samples/sample_raw_fault_injector`
+1. Compile and run this app: `go run . --host <your servicebus/eventhubs namespace, like sb.servicebus.windows.net>`. The fault injector will stay persistent until you kill it.
+1. Look in [main.go](./main.go), in the `injectorCallback` function for more on how to change this app, and what is possible within the fault injection framework.
+
+### Launching your test program
+
+Out of the box, Azure clients will not connect to the proxy, so you'll have to do some configuration. The faultinjector* samples contain examples for various languages, which you can adapt.

--- a/samples/sample_raw_fault_injector/README.md
+++ b/samples/sample_raw_fault_injector/README.md
@@ -1,7 +1,6 @@
 # Sample Raw Fault Injector
 
-This is a imple self-contained example of a fault injector. You can use this as a starting point for writing your own fault injector or to test out ideas.
-
+This is a simple self-contained example of a fault injector. You can use this as a starting point for writing your own fault injector or to test out ideas.
 NOTE: you'll be editing this project, so some basic Go language knowledge is required.
 
 ## Running

--- a/samples/sample_raw_fault_injector/main.go
+++ b/samples/sample_raw_fault_injector/main.go
@@ -1,0 +1,114 @@
+// A simple example of making your own fault injector command - see the
+
+package main
+
+import (
+	"context"
+	"log/slog"
+	"path"
+
+	"github.com/Azure/amqpfaultinjector/internal/faultinjectors"
+	"github.com/Azure/amqpfaultinjector/internal/proto/frames"
+	"github.com/Azure/amqpfaultinjector/internal/utils"
+	"github.com/spf13/cobra"
+)
+
+func main() {
+	cmd := &cobra.Command{}
+
+	host := cmd.Flags().String("host", "", "The hostname of the service we're proxying to (ex: <server>.servicebus.windows.net)")
+	logs := cmd.Flags().String("logs", ".", "The directory to write any logs or trace files")
+	_ = cmd.MarkFlagRequired("host")
+
+	localEndpoint := "127.0.0.1:5671"
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		fi, err := faultinjectors.NewFaultInjector(
+			localEndpoint,
+			*host,
+			injectorCallback,
+			&faultinjectors.FaultInjectorOptions{
+				// enable logging all traffic to a JSON file
+				JSONLFile: path.Join(*logs, "sample-rawfaultinjector-traffic.json"),
+			})
+
+		if err != nil {
+			return err
+		}
+
+		slog.Info("Starting fault injection server...", "endpoint", localEndpoint)
+		return fi.ListenAndServe()
+	}
+
+	if err := cmd.Execute(); err != nil {
+		slog.Error("Failed to execute fault injector command", "error", err)
+	}
+
+	slog.Info("Fault injector done")
+}
+
+func injectorCallback(ctx context.Context, params faultinjectors.MirrorCallbackParams) ([]faultinjectors.MetaFrame, error) {
+	// this function is the heart of any fault injection. You get access to both incoming and outgoing traffic:
+	if params.Out {
+		// outbound frames (client -> service)
+		slog.Info("Outbound frame", "type", params.Type())
+	} else {
+		// incoming frames (service -> client)
+		slog.Info("Inbound frame", "type", params.Type())
+	}
+
+	// you can make decisions about these frames, and alter traffic.
+
+	// for instance, modify a frame in-place:
+	switch frameBody := params.Frame.Body.(type) {
+	case *frames.PerformFlow:
+		slog.Info("MOD: adding an extra credit to each FLOW frame")
+		// You can use the marshalled data and just let the fault injector take care of encoding your frame.
+
+		// small modification - let's give them _more_ link credit than they asked for
+		frameBody.LinkCredit = utils.Ptr(*frameBody.LinkCredit + 1)
+
+		slightlyModifiedFrame := frames.Frame{
+			Header: params.Frame.Header,
+			Body:   frameBody,
+		}
+
+		return []faultinjectors.MetaFrame{
+			{Action: faultinjectors.MetaFrameActionPassthrough, Frame: &slightlyModifiedFrame},
+		}, nil
+	case *frames.PerformDisposition:
+		slog.Info("RAW: taking full control over encoding an AMQP frame")
+
+		// NOTE: as an example we'll just take the raw bytes for the current frame
+		// You're welcome to get the raw bytes from _any_ source, "raw frames" ignores all validation and encoding on our end.
+		frameBytes := params.Frame.Raw()
+
+		//
+		// Exercise left to the reader: "change some bytes up, or encode our own custom replacement and pass those to [frames.NewRawFrame]
+		//
+
+		rawFrame := frames.NewRawFrame(frameBytes)
+
+		return []faultinjectors.MetaFrame{
+			{Action: faultinjectors.MetaFrameActionPassthrough, Frame: rawFrame},
+		}, nil
+	default:
+		slog.Info("UNCHANGED: don't change a frame")
+		// or you could just not change a frame at all
+		return []faultinjectors.MetaFrame{
+			{Action: faultinjectors.MetaFrameActionPassthrough, Frame: params.Frame},
+		}, nil
+
+		// other frame types available:
+		// case *frames.EmptyFrame:
+		// case *frames.PerformAttach:
+		// case *frames.PerformBegin:
+		// case *frames.PerformClose:
+		// case *frames.PerformDetach:
+		// case *frames.PerformDisposition:
+		// case *frames.PerformEnd:
+		// case *frames.PerformTransfer:
+		// default:
+		// 	panic(fmt.Sprintf("unexpected frames.Body: %#v", fr))
+	}
+}


### PR DESCRIPTION
Adding in the ability to pass frames, verbatim, through a fault injector. Useful if you want to take full control and send frames that might violate AMQP, for bounds testing.
    
Also, added in a simple raw fault injector command you can use, standalone, when testing or running some example code.

Fixes #1