### PR TITLE
Fix the panic() that happens when we try to deserialize JSONLines

### DIFF
--- a/cmd/faultinjector/main_test.go
+++ b/cmd/faultinjector/main_test.go
@@ -216,8 +216,8 @@ func TestFaultInjector_VerbatimPassthrough(t *testing.T) {
 	rawFrames := 0
 
 	for _, line := range testhelpers.MustReadJSON(t, testData.JSONLFile) {
-		if line.BodyType == frames.BodyTypeRawFrame {
-			require.NotEmpty(t, line.Raw)
+		if line.FrameType == frames.BodyTypeRawFrame {
+			require.NotEmpty(t, line.RawBody())
 			rawFrames++
 		}
 	}

--- a/internal/logging/json_logger.go
+++ b/internal/logging/json_logger.go
@@ -80,7 +80,7 @@ type JSONLine struct {
 	// Metadata are extra properties that can be added by logging implementations.
 	Metadata any `json:",omitempty"`
 
-	*frames.Frame
+	Frame *frames.Frame
 
 	MessageData JSONMessageData `json:",omitempty"`
 }

--- a/internal/logging/json_logger.go
+++ b/internal/logging/json_logger.go
@@ -80,6 +80,7 @@ type JSONLine struct {
 	// Metadata are extra properties that can be added by logging implementations.
 	Metadata any `json:",omitempty"`
 
+	// Frame is the actual AMQP Frame object, including the Header and the Body.
 	Frame *frames.Frame
 
 	MessageData JSONMessageData `json:",omitempty"`

--- a/internal/logging/json_logger_test.go
+++ b/internal/logging/json_logger_test.go
@@ -45,14 +45,14 @@ func TestJSONLoggerTransformPutToken(t *testing.T) {
 		InputFrame     *frames.Frame
 		InputJSONFrame *JSONLine
 		ExpectedFrame  *frames.Frame
-		ExpectedExtra  any
+		ExpectedExtra  JSONMessageData
 	}{
 		{
 			"AttachSend",
 			&frames.Frame{Body: &frames.PerformAttach{}},
 			nil,
 			&frames.Frame{Body: &frames.PerformAttach{}},
-			nil,
+			JSONMessageData{},
 		},
 		{
 			"TransferSendAuth",
@@ -68,12 +68,14 @@ func TestJSONLoggerTransformPutToken(t *testing.T) {
 			}},
 			&JSONLine{EntityPath: "$cbs", Direction: "out"},
 			nil,
-			FilteredCBSData{
-				ApplicationProperties: map[string]any{
-					"expiration": "2025-01-17T19:56:03Z",
-					"name":       "sb://sb-testing.servicebus.windows.net/sb-testing-queue",
-					"operation":  "put-token",
-					"type":       "jwt",
+			JSONMessageData{
+				CBSData: &FilteredCBSData{
+					ApplicationProperties: map[string]any{
+						"expiration": "2025-01-17T19:56:03Z",
+						"name":       "sb://sb-testing.servicebus.windows.net/sb-testing-queue",
+						"operation":  "put-token",
+						"type":       "jwt",
+					},
 				},
 			},
 		},
@@ -82,10 +84,12 @@ func TestJSONLoggerTransformPutToken(t *testing.T) {
 			receivedFrame,
 			&JSONLine{EntityPath: "$cbs", Direction: "in"},
 			receivedFrame,
-			&models.Message{
-				ApplicationProperties: map[string]any{
-					"status-code":        int64(202),
-					"status-description": "Accepted",
+			JSONMessageData{
+				Message: &models.Message{
+					ApplicationProperties: map[string]any{
+						"status-code":        int64(202),
+						"status-description": "Accepted",
+					},
 				},
 			},
 		},
@@ -94,7 +98,9 @@ func TestJSONLoggerTransformPutToken(t *testing.T) {
 			peekSentFrame,
 			&JSONLine{EntityPath: "$management", Direction: "in"},
 			peekSentFrame,
-			peekMessage,
+			JSONMessageData{
+				Message: peekMessage,
+			},
 		},
 	}
 

--- a/internal/testhelpers/logvalidation_helpers.go
+++ b/internal/testhelpers/logvalidation_helpers.go
@@ -21,7 +21,7 @@ func ValidateLog(t *testing.T, jsonlFile string) {
 	foundCBS := false
 
 	for _, line := range lines {
-		if line.EntityPath == "$cbs" && line.Direction == "out" && line.FrameType == "Transfer" {
+		if line.EntityPath == "$cbs" && line.Direction == logging.DirectionOut && line.FrameType == frames.BodyTypeTransfer {
 			foundCBS = true
 
 			require.Equal(t, "put-token", line.MessageData.CBSData.ApplicationProperties["operation"])

--- a/internal/testhelpers/logvalidation_helpers.go
+++ b/internal/testhelpers/logvalidation_helpers.go
@@ -21,19 +21,19 @@ func ValidateLog(t *testing.T, jsonlFile string) {
 	foundCBS := false
 
 	for _, line := range lines {
-		if line.EntityPath == "$cbs" && line.Direction == "out" && line.BodyType == "Transfer" {
+		if line.EntityPath == "$cbs" && line.Direction == "out" && line.FrameType == "Transfer" {
 			foundCBS = true
 
 			require.Equal(t, "put-token", line.MessageData.CBSData.ApplicationProperties["operation"])
 			require.Empty(t, line.MessageData.Message)
-			require.Empty(t, line.Body)
+			require.Empty(t, line.Frame.Body)
 		} else {
 			// sanity check that the other attributes are getting properly written
-			require.NotEmpty(t, line.Body)
+			require.NotEmpty(t, line.Frame.Body)
 			require.NotEmpty(t, line.Direction)
 		}
 
-		switch line.BodyType {
+		switch line.FrameType {
 		case frames.BodyTypeAttach:
 		case frames.BodyTypeDetach:
 		case frames.BodyTypeFlow:
@@ -58,8 +58,8 @@ func ValidateLog(t *testing.T, jsonlFile string) {
 			require.Empty(t, line.EntityPath)
 		}
 
-		require.NotEmpty(t, line.BodyType)
-		require.Empty(t, line.Raw, "Only filled out for RawFrames, not expected for this test")
+		require.NotEmpty(t, line.FrameType)
+		require.Empty(t, line.RawBody(), "Only filled out for RawFrames, not expected for this test")
 	}
 
 	require.True(t, foundCBS)
@@ -75,15 +75,22 @@ type logLine struct {
 	Receiver   *bool   `json:",omitempty"`
 	LinkName   *string `json:",omitempty"`
 
-	Body json.RawMessage
+	Frame struct {
+		Header frames.Header
+		Body   json.RawMessage
+		Raw    []byte
+	}
 
-	BodyType    frames.BodyType `json:",omitempty"`
+	FrameType frames.BodyType `json:",omitempty"`
+
 	MessageData struct {
 		logging.JSONMessageData
 		Message json.RawMessage
 	}
+}
 
-	Raw []byte // only shows up for frames that are created with [frames.NewRawFrame]
+func (ll logLine) RawBody() []byte {
+	return ll.Frame.Raw
 }
 
 func MustReadJSON(t *testing.T, path string) []logLine {

--- a/internal/testhelpers/logvalidation_helpers_test.go
+++ b/internal/testhelpers/logvalidation_helpers_test.go
@@ -1,0 +1,90 @@
+package testhelpers
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/Azure/amqpfaultinjector/internal/logging"
+	"github.com/Azure/amqpfaultinjector/internal/proto/frames"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogLinesUnmarshalling(t *testing.T) {
+	t.Run("RawFrame", func(t *testing.T) {
+		now := time.Now().UTC()
+
+		// deserialization and serialization aren't quite matched up right now
+		data, err := json.Marshal(logging.JSONLine{
+			Time:       now,
+			Direction:  logging.DirectionOut,
+			EntityPath: "entity path",
+			// raw frames, when serialized, will output an extra field called 'Raw', which contains
+			// the actual bytes. This intentionally bypasses any sort of interpretation or serialization
+			// since the data might not actually be valid AMQP frame data.
+			FrameType: frames.BodyTypeRawFrame,
+			Frame:     frames.NewRawFrame([]byte("arbitrary bytes")),
+		})
+		require.NoError(t, err)
+		require.NotEmpty(t, data)
+
+		var actualLogLine *logLine
+		err = json.Unmarshal(data, &actualLogLine)
+		require.NoError(t, err)
+
+		require.Equal(t, &logLine{
+			Time:       now,
+			Direction:  logging.DirectionOut,
+			EntityPath: "entity path",
+			Frame: struct {
+				Header frames.Header
+				Body   json.RawMessage
+				Raw    []byte
+			}{
+				Body: json.RawMessage([]byte("{}")),
+				Raw:  []byte("arbitrary bytes"),
+			},
+			FrameType: frames.BodyTypeRawFrame,
+		}, actualLogLine)
+	})
+
+	t.Run("AttachFrame", func(t *testing.T) {
+		now := time.Now().UTC()
+
+		// deserialization and serialization aren't quite matched up right now
+		data, err := json.Marshal(logging.JSONLine{
+			Time:       now,
+			Direction:  logging.DirectionOut,
+			EntityPath: "entity path",
+			// raw frames, when serialized, will output an extra field called 'Raw', which contains
+			// the actual bytes. This intentionally bypasses any sort of interpretation or serialization
+			// since the data might not actually be valid AMQP frame data.
+			FrameType: frames.BodyTypeAttach,
+			Frame: &frames.Frame{
+				Body: &frames.PerformAttach{
+					Name: "attach-name",
+				},
+			},
+		})
+		require.NoError(t, err)
+		require.NotEmpty(t, data)
+
+		var actualLogLine *logLine
+		err = json.Unmarshal(data, &actualLogLine)
+		require.NoError(t, err)
+
+		require.Equal(t, now, actualLogLine.Time)
+		require.Equal(t, logging.DirectionOut, actualLogLine.Direction)
+		require.Equal(t, "entity path", actualLogLine.EntityPath)
+
+		var attachFrame *frames.PerformAttach
+		err = json.Unmarshal(actualLogLine.Frame.Body, &attachFrame)
+		require.NoError(t, err)
+
+		require.Equal(t, &frames.PerformAttach{
+			Name: "attach-name",
+		}, attachFrame)
+
+		require.Nil(t, actualLogLine.RawBody())
+	})
+}


### PR DESCRIPTION
Frame, which has newly acquired the ability to _deserialize_ itself properly, was embedded in JSONLine. This meant that the new MarshalJSON() function, on _Frame_, would actually take over and be the MarshalJSON for JSONLine, which was NOT the intention.

This would have been caught with a very simple test, and also _was_ caught with our live testing, which I failed to run. So as penance I've also added in a unit test.

Fixes #29