### PR TITLE
Make it simple to re-use certificates

### DIFF
--- a/amqp_proxy_test.go
+++ b/amqp_proxy_test.go
@@ -71,6 +71,7 @@ func mustCreateAMQPProxy(t *testing.T) testAMQPProxy {
 		serviceBusEndpoint,
 		&amqpfaultinjector.AMQPProxyOptions{
 			BaseJSONName: jsonlFile,
+			CertDir:      dir,
 		})
 	require.NoError(t, err)
 

--- a/amqp_proxy_test.go
+++ b/amqp_proxy_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -64,7 +64,7 @@ func mustCreateAMQPProxy(t *testing.T) testAMQPProxy {
 		os.RemoveAll(dir)
 	})
 
-	jsonlFile := path.Join(dir, "amqpproxy-traffic")
+	jsonlFile := filepath.Join(dir, "amqpproxy-traffic")
 
 	amqpProxy, err := amqpfaultinjector.NewAMQPProxy(
 		"localhost:5671",

--- a/cmd/amqpproxy/main.go
+++ b/cmd/amqpproxy/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"context"
-	"path"
+	"path/filepath"
 
 	"github.com/Azure/amqpfaultinjector"
 	"github.com/Azure/amqpfaultinjector/cmd/internal"
@@ -43,15 +43,15 @@ func newAMQPProxyCommand(ctx context.Context) *cobra.Command {
 		var baseBinName string
 
 		if *enableBinFiles {
-			baseBinName = path.Join(cf.LogsDir, "amqpproxy-bin")
+			baseBinName = filepath.Join(cf.LogsDir, "amqpproxy-bin")
 		}
 
 		fi, err := amqpfaultinjector.NewAMQPProxy(
 			"localhost:5671",
 			cf.Host,
 			&amqpfaultinjector.AMQPProxyOptions{
-				BaseJSONName:               path.Join(cf.LogsDir, "amqpproxy-traffic"),
-				TLSKeyLogFile:              path.Join(cf.LogsDir, "amqpproxy-tlskeys.txt"),
+				BaseJSONName:               filepath.Join(cf.LogsDir, "amqpproxy-traffic"),
+				TLSKeyLogFile:              filepath.Join(cf.LogsDir, "amqpproxy-tlskeys.txt"),
 				BaseBinName:                baseBinName,
 				DisableTLSForLocalEndpoint: *disableTLS,
 				DisableStateTracing:        *disableStateTracking,

--- a/cmd/amqpproxy/main.go
+++ b/cmd/amqpproxy/main.go
@@ -55,6 +55,7 @@ func newAMQPProxyCommand(ctx context.Context) *cobra.Command {
 				BaseBinName:                baseBinName,
 				DisableTLSForLocalEndpoint: *disableTLS,
 				DisableStateTracing:        *disableStateTracking,
+				CertDir:                    cf.CertDir,
 			})
 
 		if err != nil {

--- a/cmd/amqpproxy/main_test.go
+++ b/cmd/amqpproxy/main_test.go
@@ -14,13 +14,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var testEnv = testhelpers.LoadEnv("../..")
+var testEnv testhelpers.TestEnv
 
 func TestMain(m *testing.M) {
+	testEnv = testhelpers.LoadEnv("../..")
 	os.Exit(m.Run())
 }
 
 func TestAMQPProxy(t *testing.T) {
+	testEnv.SkipIfNotLive(t)
+
 	testData := mustCreateAMQPProxy(t, []string{})
 
 	receiver, err := testData.ServiceBusClient.NewReceiverForQueue(testData.ServiceBusQueue, nil)
@@ -91,6 +94,7 @@ func mustCreateAMQPProxy(t *testing.T, args []string) *testAMQPProxy {
 	args = append(args,
 		cmd.Name(),
 		"--logs", dir,
+		"--cert", dir,
 		"--host", testEnv.ServiceBusEndpoint)
 
 	t.Logf("Command line args for fault injector: %#v", args)

--- a/cmd/amqpproxy/main_test.go
+++ b/cmd/amqpproxy/main_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -100,7 +100,7 @@ func mustCreateAMQPProxy(t *testing.T, args []string) *testAMQPProxy {
 	t.Logf("Command line args for fault injector: %#v", args)
 	cmd.SetArgs(args)
 
-	jsonlFile := path.Join(dir, "amqpproxy-traffic-1.json") // note, we're assuming this test only creates a single connection
+	jsonlFile := filepath.Join(dir, "amqpproxy-traffic-1.json") // note, we're assuming this test only creates a single connection
 
 	go func() {
 		t.Logf("Starting AMQP proxy command")

--- a/cmd/faultinjector/commands.go
+++ b/cmd/faultinjector/commands.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"path"
+	"path/filepath"
 	"time"
 
 	"github.com/Azure/amqpfaultinjector/cmd/internal"
@@ -52,8 +52,8 @@ func runFaultInjector(ctx context.Context, cmd *cobra.Command, injector faultinj
 		cf.Host,
 		injector,
 		&faultinjectors.FaultInjectorOptions{
-			JSONLFile:     path.Join(cf.LogsDir, "faultinjector-traffic.json"),
-			TLSKeyLogFile: path.Join(cf.LogsDir, "faultinjector-tlskeys.txt"),
+			JSONLFile:     filepath.Join(cf.LogsDir, "faultinjector-traffic.json"),
+			TLSKeyLogFile: filepath.Join(cf.LogsDir, "faultinjector-tlskeys.txt"),
 			AddressFile:   addressFile,
 			CertDir:       cf.CertDir,
 		})

--- a/cmd/faultinjector/commands.go
+++ b/cmd/faultinjector/commands.go
@@ -55,6 +55,7 @@ func runFaultInjector(ctx context.Context, cmd *cobra.Command, injector faultinj
 			JSONLFile:     path.Join(cf.LogsDir, "faultinjector-traffic.json"),
 			TLSKeyLogFile: path.Join(cf.LogsDir, "faultinjector-tlskeys.txt"),
 			AddressFile:   addressFile,
+			CertDir:       cf.CertDir,
 		})
 
 	if err != nil {

--- a/cmd/faultinjector/main_test.go
+++ b/cmd/faultinjector/main_test.go
@@ -18,13 +18,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var testEnv = testhelpers.LoadEnv("../..")
+var testEnv testhelpers.TestEnv
 
 func TestMain(m *testing.M) {
+	testEnv = testhelpers.LoadEnv("../..")
 	os.Exit(m.Run())
 }
 
 func TestFaultInjector_Logging(t *testing.T) {
+	testEnv.SkipIfNotLive(t)
+
 	t.Run("Send", func(t *testing.T) {
 		testData := mustCreateFaultInjector(t, newPassthroughCommand, nil)
 
@@ -88,6 +91,8 @@ func TestFaultInjector_Logging(t *testing.T) {
 }
 
 func TestFaultInjector_DetachAfterTransfer(t *testing.T) {
+	testEnv.SkipIfNotLive(t)
+
 	testData := mustCreateFaultInjector(t, newDetachAfterTransferCommand, []string{"--times", "2"})
 
 	t.Run("sender", func(t *testing.T) {
@@ -115,6 +120,8 @@ func TestFaultInjector_DetachAfterTransfer(t *testing.T) {
 }
 
 func TestFaultInjector_DetachAfterDelay(t *testing.T) {
+	testEnv.SkipIfNotLive(t)
+
 	testData := mustCreateFaultInjector(t, newDetachAfterDelayCommand, nil)
 
 	{
@@ -138,6 +145,8 @@ func TestFaultInjector_DetachAfterDelay(t *testing.T) {
 }
 
 func TestFaultInjector_SlowTransferFrames(t *testing.T) {
+	testEnv.SkipIfNotLive(t)
+
 	testData := mustCreateFaultInjector(t, newSlowTransferFrames, nil)
 
 	{
@@ -177,6 +186,8 @@ func TestFaultInjector_SlowTransferFrames(t *testing.T) {
 }
 
 func TestFaultInjector_VerbatimPassthrough(t *testing.T) {
+	testEnv.SkipIfNotLive(t)
+
 	testData := mustCreateFaultInjector(t, func(ctx context.Context) *cobra.Command {
 		cmd := &cobra.Command{
 			Use: "verbatim_passthrough",
@@ -258,7 +269,8 @@ func mustCreateFaultInjector(t *testing.T, createCommand func(ctx context.Contex
 	args = append(args,
 		subCommand.Name(),
 		"--logs", dir,
-		"--host", testEnv.ServiceBusEndpoint)
+		"--host", testEnv.ServiceBusEndpoint,
+		"--cert", dir)
 
 	rootCmd := newRootCommand()
 	rootCmd.AddCommand(subCommand)

--- a/cmd/faultinjector/main_test.go
+++ b/cmd/faultinjector/main_test.go
@@ -5,7 +5,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -278,7 +278,7 @@ func mustCreateFaultInjector(t *testing.T, createCommand func(ctx context.Contex
 	t.Logf("Command line args for fault injector: %#v", args)
 	rootCmd.SetArgs(args)
 
-	jsonlFile := path.Join(dir, "faultinjector-traffic.json")
+	jsonlFile := filepath.Join(dir, "faultinjector-traffic.json")
 
 	go func() {
 		t.Logf("Starting fault injector command")

--- a/cmd/internal/common_flags.go
+++ b/cmd/internal/common_flags.go
@@ -4,7 +4,7 @@ import "github.com/spf13/cobra"
 
 const HostFlagName = "host"
 const LogsFlagName = "logs"
-const CertFlagName = "certs"
+const CertFlagName = "cert"
 
 type CommonFlags struct {
 	Host    string
@@ -15,7 +15,7 @@ type CommonFlags struct {
 func AddCommonFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().String(HostFlagName, "", "The hostname of the service we're proxying to (ex: <server>.servicebus.windows.net)")
 	cmd.PersistentFlags().String(LogsFlagName, ".", "The directory to write any logs or trace files")
-	cmd.PersistentFlags().String(CertFlagName, ".", "The directory to write the TLS cert for the proxy's endpoint. If the cert already exists, it is re-used.")
+	cmd.PersistentFlags().String(CertFlagName, ".", "The directory to write the TLS server.cert and server.key used for the proxy's endpoint. If the files already exist, they are re-used.")
 
 	_ = cmd.MarkPersistentFlagRequired(HostFlagName)
 }

--- a/cmd/internal/common_flags.go
+++ b/cmd/internal/common_flags.go
@@ -4,15 +4,18 @@ import "github.com/spf13/cobra"
 
 const HostFlagName = "host"
 const LogsFlagName = "logs"
+const CertFlagName = "certs"
 
 type CommonFlags struct {
 	Host    string
 	LogsDir string
+	CertDir string
 }
 
 func AddCommonFlags(cmd *cobra.Command) {
-	cmd.PersistentFlags().String("host", "", "The hostname of the service we're proxying to (ex: <server>.servicebus.windows.net)")
-	cmd.PersistentFlags().String("logs", ".", "The directory to write any logs or trace files")
+	cmd.PersistentFlags().String(HostFlagName, "", "The hostname of the service we're proxying to (ex: <server>.servicebus.windows.net)")
+	cmd.PersistentFlags().String(LogsFlagName, ".", "The directory to write any logs or trace files")
+	cmd.PersistentFlags().String(CertFlagName, ".", "The directory to write the TLS cert for the proxy's endpoint. If the cert already exists, it is re-used.")
 
 	_ = cmd.MarkPersistentFlagRequired(HostFlagName)
 }
@@ -30,8 +33,15 @@ func ExtractCommonFlags(cmd *cobra.Command) (CommonFlags, error) {
 		return CommonFlags{}, err
 	}
 
+	cert, err := cmd.Flags().GetString(CertFlagName)
+
+	if err != nil {
+		return CommonFlags{}, err
+	}
+
 	return CommonFlags{
 		Host:    host,
 		LogsDir: logs,
+		CertDir: cert,
 	}, nil
 }

--- a/internal/faultinjectors/mirroring_test.go
+++ b/internal/faultinjectors/mirroring_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"io"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -150,7 +150,7 @@ func newFrameLoggerForTest(t *testing.T, prefix string) *logging.FrameLogger {
 
 	t.Cleanup(func() { os.RemoveAll(dir) })
 
-	jsonlFile := path.Join(dir, "mirror-traffic.json")
+	jsonlFile := filepath.Join(dir, "mirror-traffic.json")
 
 	fl, err := logging.NewFrameLogger(jsonlFile)
 	require.NoError(t, err)

--- a/internal/shared/certs.go
+++ b/internal/shared/certs.go
@@ -1,0 +1,40 @@
+package shared
+
+import (
+	"crypto/tls"
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/madflojo/testcerts"
+)
+
+var emptyCert = tls.Certificate{}
+
+// LoadOrCreateCert will create a server.key and a server.cert in the specified directory. If the files already
+// exist it will load them, instead.
+func LoadOrCreateCert(dir string) (certFile string, keyFile string, cert tls.Certificate, err error) {
+	certFile = path.Join(dir, "server.crt")
+	keyFile = path.Join(dir, "server.key")
+
+	if err := os.MkdirAll(dir, 0600); err != nil {
+		return "", "", emptyCert, fmt.Errorf("failed to create cert directory: %w", err)
+	}
+
+	_, certErr := os.Stat(certFile)
+	_, keyErr := os.Stat(keyFile)
+
+	if os.IsNotExist(certErr) || os.IsNotExist(keyErr) {
+		if err := testcerts.GenerateCertsToFile(certFile, keyFile); err != nil {
+			return "", "", emptyCert, err
+		}
+	}
+
+	cert, err = tls.LoadX509KeyPair(certFile, keyFile)
+
+	if err != nil {
+		return "", "", emptyCert, fmt.Errorf("failed to load cert: %w", err)
+	}
+
+	return
+}

--- a/internal/shared/certs.go
+++ b/internal/shared/certs.go
@@ -4,7 +4,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/madflojo/testcerts"
 )
@@ -14,8 +14,8 @@ var emptyCert = tls.Certificate{}
 // LoadOrCreateCert will create a server.key and a server.cert in the specified directory. If the files already
 // exist it will load them, instead.
 func LoadOrCreateCert(dir string) (certFile string, keyFile string, cert tls.Certificate, err error) {
-	certFile = path.Join(dir, "server.crt")
-	keyFile = path.Join(dir, "server.key")
+	certFile = filepath.Join(dir, "server.crt")
+	keyFile = filepath.Join(dir, "server.key")
 
 	if err := os.MkdirAll(dir, 0600); err != nil {
 		return "", "", emptyCert, fmt.Errorf("failed to create cert directory: %w", err)

--- a/internal/shared/certs_test.go
+++ b/internal/shared/certs_test.go
@@ -1,0 +1,48 @@
+package shared_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/Azure/amqpfaultinjector/internal/shared"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadOrCreateCert(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "temp-cert-test-*")
+	require.NoError(t, err)
+
+	defer os.RemoveAll(tmpDir)
+
+	certFile, keyFile, cert, err := shared.LoadOrCreateCert(tmpDir)
+	require.NoError(t, err)
+	require.FileExists(t, certFile)
+	require.FileExists(t, keyFile)
+	require.NotEmpty(t, cert)
+
+	require.True(t, strings.HasSuffix(certFile, "/server.crt"))
+	require.True(t, strings.HasSuffix(keyFile, "/server.key"))
+
+	beforeCertStat, err := os.Stat(certFile)
+	require.NoError(t, err)
+
+	beforeKeyStat, err := os.Stat(keyFile)
+	require.NoError(t, err)
+
+	// now, "regen" again - it should just use the existing key/cert and not create a new one.
+	certFile, keyFile, cert, err = shared.LoadOrCreateCert(tmpDir)
+	require.NoError(t, err)
+	require.FileExists(t, certFile)
+	require.FileExists(t, keyFile)
+	require.NotEmpty(t, cert)
+
+	afterCertStat, err := os.Stat(certFile)
+	require.NoError(t, err)
+
+	afterKeyStat, err := os.Stat(keyFile)
+	require.NoError(t, err)
+
+	require.Equal(t, beforeCertStat.ModTime(), afterCertStat.ModTime())
+	require.Equal(t, beforeKeyStat.ModTime(), afterKeyStat.ModTime())
+}

--- a/internal/testhelpers/env.go
+++ b/internal/testhelpers/env.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 	"os"
 	"path"
+	"testing"
 
 	"github.com/joho/godotenv"
 )
@@ -11,26 +12,28 @@ import (
 type TestEnv struct {
 	ServiceBusEndpoint string
 	ServiceBusQueue    string
-	LiveTests          bool
+	Disabled           string
+}
+
+func (te TestEnv) SkipIfNotLive(t *testing.T) {
+	if te.Disabled != "" {
+		t.Skipf("Skipping test: %s", te.Disabled)
+	}
 }
 
 func LoadEnv(dir string) TestEnv {
-	var envs []string
-
-	if dir != "" {
-		envs = []string{path.Join(dir, ".env")}
-	}
+	envs := []string{path.Join(dir, ".env")}
 
 	if err := godotenv.Load(envs...); err != nil {
 		slog.Warn("No .env file - live tests will not run")
-		return TestEnv{LiveTests: false}
+		return TestEnv{Disabled: "No .env file - live tests will not run"}
 	}
 
 	te := TestEnv{ServiceBusEndpoint: os.Getenv("SERVICEBUS_ENDPOINT"), ServiceBusQueue: os.Getenv("SERVICEBUS_QUEUE")}
 
 	if te.ServiceBusEndpoint == "" || te.ServiceBusQueue == "" {
 		slog.Error("SERVICEBUS_ENDPOINT and SERVICEBUS_QUEUE must be defined in the environment")
-		return TestEnv{LiveTests: false}
+		return TestEnv{Disabled: "SERVICEBUS_ENDPOINT and SERVICEBUS_QUEUE must be defined in the environment"}
 	}
 
 	return te

--- a/internal/testhelpers/env.go
+++ b/internal/testhelpers/env.go
@@ -12,12 +12,12 @@ import (
 type TestEnv struct {
 	ServiceBusEndpoint string
 	ServiceBusQueue    string
-	Disabled           string
+	SkipReason         string
 }
 
 func (te TestEnv) SkipIfNotLive(t *testing.T) {
-	if te.Disabled != "" {
-		t.Skipf("Skipping test: %s", te.Disabled)
+	if te.SkipReason != "" {
+		t.Skipf("Skipping test: %s", te.SkipReason)
 	}
 }
 
@@ -26,14 +26,14 @@ func LoadEnv(dir string) TestEnv {
 
 	if err := godotenv.Load(envs...); err != nil {
 		slog.Warn("No .env file - live tests will not run")
-		return TestEnv{Disabled: "No .env file - live tests will not run"}
+		return TestEnv{SkipReason: "No .env file - live tests will not run"}
 	}
 
 	te := TestEnv{ServiceBusEndpoint: os.Getenv("SERVICEBUS_ENDPOINT"), ServiceBusQueue: os.Getenv("SERVICEBUS_QUEUE")}
 
 	if te.ServiceBusEndpoint == "" || te.ServiceBusQueue == "" {
 		slog.Error("SERVICEBUS_ENDPOINT and SERVICEBUS_QUEUE must be defined in the environment")
-		return TestEnv{Disabled: "SERVICEBUS_ENDPOINT and SERVICEBUS_QUEUE must be defined in the environment"}
+		return TestEnv{SkipReason: "SERVICEBUS_ENDPOINT and SERVICEBUS_QUEUE must be defined in the environment"}
 	}
 
 	return te

--- a/samples/sample_raw_fault_injector/main.go
+++ b/samples/sample_raw_fault_injector/main.go
@@ -5,7 +5,7 @@ package main
 import (
 	"context"
 	"log/slog"
-	"path"
+	"path/filepath"
 
 	"github.com/Azure/amqpfaultinjector/internal/faultinjectors"
 	"github.com/Azure/amqpfaultinjector/internal/proto/frames"
@@ -29,7 +29,7 @@ func main() {
 			injectorCallback,
 			&faultinjectors.FaultInjectorOptions{
 				// enable logging all traffic to a JSON file
-				JSONLFile: path.Join(*logs, "sample-rawfaultinjector-traffic.json"),
+				JSONLFile: filepath.Join(*logs, "sample-rawfaultinjector-traffic.json"),
 			})
 
 		if err != nil {


### PR DESCRIPTION
To better support #2 (ie: auto cert installation) I've added a switch that lets you store the certificates in a specific directory and reload them. This should make it easier for people to install the self-signed cert into their cert store (manually), and then continue to reuse it.

Or, if they should choose, they can generate their own cert/key pair, and use that instead.