### PR TITLE
Dump out session links in the log files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ samples/faultinjectorsample_js/package-lock.json
 
 # temp folder when we're creating a release
 _bin
+server.crt
+server.key

--- a/internal/logging/frame_logger.go
+++ b/internal/logging/frame_logger.go
@@ -40,12 +40,19 @@ func (l *FrameLogger) AddFrame(out bool, fr *frames.Frame, metadata any) error {
 		direction = DirectionOut
 	}
 
+	var sessionLinks []string
+
+	if _, isDisposition := fr.Body.(*frames.PerformDisposition); isDisposition && l.sm != nil {
+		sessionLinks = l.sm.LookupLocalSessionLinks(fr.Header.Channel)
+	}
+
 	jsonLine := &JSONLine{
-		Time:      time.Now(),
-		Direction: direction,
-		Frame:     fr,
-		FrameType: fr.Body.Type(),
-		Metadata:  metadata,
+		Time:         time.Now(),
+		Direction:    direction,
+		Frame:        fr,
+		FrameType:    fr.Body.Type(),
+		SessionLinks: sessionLinks,
+		Metadata:     metadata,
 	}
 
 	l.sm.AddFrame(out, fr)


### PR DESCRIPTION
- Dump out the list of links associated with a session when we're doing DISPOSITIONs.
- Ignore server.key/server.crt that get autogen'd.