### PR TITLE
[FI] Injector to split TRANSFER frame into multiple with single-byte payload

### DIFF
--- a/cmd/faultinjector/commands.go
+++ b/cmd/faultinjector/commands.go
@@ -141,6 +141,19 @@ func newSlowTransferFrames(ctx context.Context) *cobra.Command {
 	return cmd
 }
 
+func newMultiTransferInjector(ctx context.Context) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "multi_transfer",
+		Short: "Splits any incoming TRANSFER frames into many TRANSFER frames",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			injector := faultinjectors.NewMultiTransferInjector()
+			return runFaultInjector(ctx, cmd, injector.Callback)
+		},
+	}
+
+	return cmd
+}
+
 // newPassthroughCommand creates a command that passes all frames through, unchanged. Useful if trying to troubleshoot.
 func newPassthroughCommand(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{

--- a/cmd/faultinjector/main.go
+++ b/cmd/faultinjector/main.go
@@ -14,6 +14,7 @@ func main() {
 
 	// transfer commands
 	rootCmd.AddCommand(newSlowTransferFrames(context.Background()))
+	rootCmd.AddCommand(newMultiTransferInjector(context.Background()))
 
 	// passthrough/diagnostics
 	rootCmd.AddCommand(newPassthroughCommand(context.Background()))

--- a/internal/faultinjectors/multi_transfer_injector.go
+++ b/internal/faultinjectors/multi_transfer_injector.go
@@ -1,0 +1,47 @@
+package faultinjectors
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/richardpark-msft/amqpfaultinjector/internal/proto/frames"
+)
+
+func NewMultiTransferInjector() *MultiTransferInjector {
+	return &MultiTransferInjector{}
+}
+
+type MultiTransferInjector struct {
+}
+
+// Callback is called by the FaultInjector framework. The current frame is passed in params.Frame.
+// Your injector should look at the frame and transform it into the result you want, using the returned
+// faultinjector.MetaFrame(s).
+func (inj *MultiTransferInjector) Callback(ctx context.Context, params MirrorCallbackParams) ([]MetaFrame, error) {
+	// When dealing with a particular link's frames you'll often want to see what the original
+	// connection parameters were, the entity path. You can get the current link's ATTACH frame properties
+	// at any time using [MirrorCallbackParams.AttachFrame].
+	transferFrame, isTransfer := params.Frame.Body.(*frames.PerformTransfer)
+
+	if isTransfer && !params.Out && !params.ManagementOrCBS() {
+		var newFrames []MetaFrame
+		for i, singlePayloadByte := range transferFrame.Payload {
+			// Copy the transfer frame, but set the payload to just a single byte
+			clonedFrame := *transferFrame // shallow copy of the original transfer frame
+			clonedFrame.Payload = []byte{singlePayloadByte}
+			clonedFrame.More = i != len(transferFrame.Payload)-1 // the last frame should not have the "More" flag set.
+
+			newFrames = append(newFrames, MetaFrame{
+				Action:      MetaFrameActionAdded,
+				Frame:       &frames.Frame{Header: params.Frame.Header, Body: &clonedFrame},
+				Description: fmt.Sprintf("Frame %d of %d", i+1, len(transferFrame.Payload)),
+			})
+		}
+
+		return newFrames, nil
+	}
+
+	return []MetaFrame{
+		{Action: MetaFrameActionPassthrough, Frame: params.Frame},
+	}, nil
+}

--- a/internal/faultinjectors/multi_transfer_injector_test.go
+++ b/internal/faultinjectors/multi_transfer_injector_test.go
@@ -1,0 +1,86 @@
+package faultinjectors_test
+
+import (
+	"context"
+	"testing"
+
+	faultinjectors "github.com/richardpark-msft/amqpfaultinjector/internal/faultinjectors"
+	"github.com/richardpark-msft/amqpfaultinjector/internal/proto"
+	"github.com/richardpark-msft/amqpfaultinjector/internal/proto/frames"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMultiTransferInjector(t *testing.T) {
+	// Initialize the MultiTransferInjector
+	injector := faultinjectors.NewMultiTransferInjector()
+	var stateMap = &proto.StateMap{}
+	// Pass incoming and outgoing ATTACH frames to populate the state map
+	var incomingAttachFrame = &frames.Frame{
+		Header: frames.Header{
+			Channel: 0,
+		},
+		Body: &frames.PerformAttach{
+			Role:   false,
+			Handle: 2,
+		},
+	}
+	params := faultinjectors.MirrorCallbackParams{
+		StateMap: stateMap,
+		Frame:    incomingAttachFrame,
+		Out:      false,
+	}
+	resultFrames, err := injector.Callback(context.Background(), params)
+	require.NoError(t, err)
+	var outgoingAttachFrame = &frames.Frame{
+		Header: frames.Header{
+			Channel: 1,
+		},
+		Body: &frames.PerformAttach{
+			Role:   true,
+			Handle: 3,
+		},
+	}
+	params = faultinjectors.MirrorCallbackParams{
+		StateMap: stateMap,
+		Frame:    outgoingAttachFrame,
+		Out:      true,
+	}
+	resultFrames, err = injector.Callback(context.Background(), params)
+	require.NoError(t, err)
+
+	// Create a PerformTransfer frame
+	var transferBody = &frames.PerformTransfer{
+		Payload: []byte("Hello world!"),
+		More:    false,
+		Handle:  1,
+	}
+	var transferFrame = &frames.Frame{
+		Body: transferBody,
+		Header: frames.Header{
+			Channel: 0,
+		},
+	}
+	params = faultinjectors.MirrorCallbackParams{
+		StateMap: stateMap,
+		Frame:    transferFrame,
+		Out:      false,
+	}
+	resultFrames, err = injector.Callback(context.Background(), params)
+	require.NoError(t, err)
+	// 	Validate the result
+	require.Len(t, resultFrames, len(transferBody.Payload)) // Each byte should result in a separate frame
+
+	for i, frame := range resultFrames {
+		require.Equal(t, faultinjectors.MetaFrameActionAdded, frame.Action)
+		require.NotNil(t, frame.Frame)
+
+		// Validate the payload of each frame
+		clonedTransferFrame, ok := frame.Frame.Body.(*frames.PerformTransfer)
+		require.True(t, ok)
+		require.Equal(t, []byte{transferBody.Payload[i]}, clonedTransferFrame.Payload)
+
+		// Validate the "More" flag
+		expectedMore := i != len(transferBody.Payload)-1
+		require.Equal(t, expectedMore, clonedTransferFrame.More)
+	}
+}

--- a/samples/faultinjectorsample_python/README.md
+++ b/samples/faultinjectorsample_python/README.md
@@ -64,8 +64,8 @@ Find more samples [here](https://github.com/Azure/azure-sdk-for-python/tree/main
 
 2. Add the following to a `.env` file:
 ```
-SERVICEBUS_FULLY_QUALIFIED_NAMESPACE=<your-sb-namespace>.servicebus.windows.net
-SERVICEBUS_QUEUE_NAME=<your-queue-name>
+SERVICEBUS_ENDPOINT=<your-sb-namespace>.servicebus.windows.net
+SERVICEBUS_QUEUE=<your-queue-name>
 EVENT_HUB_HOSTNAME=<your-eh-namespace>.servicebus.windows.net
 EVENT_HUB_NAME=<your-hub>
 ```

--- a/samples/faultinjectorsample_python/servicebus/recv.py
+++ b/samples/faultinjectorsample_python/servicebus/recv.py
@@ -10,7 +10,6 @@ from dotenv import find_dotenv, load_dotenv
 import ssl
 from azure.servicebus import ServiceBusClient, TransportType
 from azure.identity import DefaultAzureCredential
-from datetime import datetime
 
 
 import logging
@@ -48,8 +47,9 @@ with servicebus_client:
 
     receiver = servicebus_client.get_queue_receiver(queue_name=QUEUE_NAME)
     with receiver:
-        received_msgs = receiver.receive_messages(max_message_count=1, max_wait_time=5)
+        received_msgs = receiver.receive_messages(max_message_count=1)
         print('Received messages.')
         for msg in received_msgs:
+            print(msg)
             receiver.complete_message(msg)
         print('Completed messages.')

--- a/samples/faultinjectorsample_python/servicebus/recv.py
+++ b/samples/faultinjectorsample_python/servicebus/recv.py
@@ -24,8 +24,8 @@ logger.addHandler(handler)
 
 find_dotenv()
 load_dotenv()
-FULLY_QUALIFIED_NAMESPACE = os.environ["SERVICEBUS_FULLY_QUALIFIED_NAMESPACE"]
-QUEUE_NAME = os.environ["SERVICEBUS_QUEUE_NAME"]
+FULLY_QUALIFIED_NAMESPACE = os.environ["SERVICEBUS_ENDPOINT"]
+QUEUE_NAME = os.environ["SERVICEBUS_QUEUE"]
 # The custom endpoint address to use for establishing a connection to the Service Bus service,
 # allowing network requests to be routed through any application gateways
 # or other paths needed for the host environment.

--- a/samples/faultinjectorsample_python/servicebus/send.py
+++ b/samples/faultinjectorsample_python/servicebus/send.py
@@ -28,8 +28,8 @@ logger.addHandler(handler)
 
 find_dotenv()
 load_dotenv()
-FULLY_QUALIFIED_NAMESPACE = os.environ["SERVICEBUS_FULLY_QUALIFIED_NAMESPACE"]
-QUEUE_NAME = os.environ["SERVICEBUS_QUEUE_NAME"]
+FULLY_QUALIFIED_NAMESPACE = os.environ["SERVICEBUS_ENDPOINT"]
+QUEUE_NAME = os.environ["SERVICEBUS_QUEUE"]
 
 print(f"Connecting to {FULLY_QUALIFIED_NAMESPACE}, using queue {QUEUE_NAME}")
 
@@ -41,6 +41,15 @@ CUSTOM_ENDPOINT_ADDRESS = "sb://localhost:5671"
 context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
 context.check_hostname = False
 context.verify_mode = ssl.CERT_NONE
+
+def send_single_message(sender):
+    message = ServiceBusMessage("Single Message")
+    sender.send_messages(message)
+
+def send_large_messages(sender):
+    for _ in range(200):
+        message = "A" * 1024 * 600 # 600 KB
+        sender.send_messages(ServiceBusMessage(message))
 
 credential = DefaultAzureCredential()
 servicebus_client = ServiceBusClient(
@@ -54,7 +63,8 @@ servicebus_client = ServiceBusClient(
 with servicebus_client:
     sender = servicebus_client.get_queue_sender(queue_name=QUEUE_NAME)
     with sender:
-        message = ServiceBusMessage("Single Message")
-        sender.send_messages(message)
+        send_single_message(sender)
+        # Namespace should be premium to send messages > 256 KB
+        send_large_messages(sender)
 
 print('Finished sending.')

--- a/samples/faultinjectorsample_python/servicebus/send.py
+++ b/samples/faultinjectorsample_python/servicebus/send.py
@@ -65,6 +65,6 @@ with servicebus_client:
     with sender:
         send_single_message(sender)
         # Namespace should be premium to send messages > 256 KB
-        send_large_messages(sender)
+        # send_large_messages(sender)
 
 print('Finished sending.')


### PR DESCRIPTION
Adding a fault injector which will split the payload of an incoming TRANSFER frame (include body, application properties, annotations, etc.) into multiple TRANSFER frames, where each TRANSFER frame payload is a single byte of the original payload. As a result, the number of incoming frames corresponds directly to the size of the original payload.