### PR TITLE
Handle ATTACH where the frame that's returned has an empty Source and Target

### DIFF
--- a/internal/proto/frames/bodies.go
+++ b/internal/proto/frames/bodies.go
@@ -721,13 +721,13 @@ func (a *PerformAttach) GetHandle() *uint32 { return &a.Handle }
 // Entity returns the underlying target or source for this ATTACH frame.
 func (a *PerformAttach) Address(out bool) (address string) {
 	switch {
-	case out && a.Role == encoding.RoleSender:
+	case out && a.Role == encoding.RoleSender && a.Target != nil:
 		return a.Target.Address
-	case out && a.Role == encoding.RoleReceiver:
+	case out && a.Role == encoding.RoleReceiver && a.Source != nil:
 		return a.Source.Address
 
 	// NOTE: the source and target are reversed when the ATTACH frames
-	// are incoming.
+	// are incoming since the roles are also reversed.
 	case !out && a.Role == encoding.RoleSender && a.Source != nil:
 		return a.Source.Address
 	case !out && a.Role == encoding.RoleReceiver && a.Target != nil:

--- a/internal/proto/frames/bodies.go
+++ b/internal/proto/frames/bodies.go
@@ -728,9 +728,9 @@ func (a *PerformAttach) Address(out bool) (address string) {
 
 	// NOTE: the source and target are reversed when the ATTACH frames
 	// are incoming.
-	case !out && a.Role == encoding.RoleSender:
+	case !out && a.Role == encoding.RoleSender && a.Source != nil:
 		return a.Source.Address
-	case !out && a.Role == encoding.RoleReceiver:
+	case !out && a.Role == encoding.RoleReceiver && a.Target != nil:
 		return a.Target.Address
 	default:
 		return ""

--- a/internal/proto/frames/bodies_test.go
+++ b/internal/proto/frames/bodies_test.go
@@ -34,7 +34,7 @@ func TestPerformAttach(t *testing.T) {
 		// with those values 'nil', and a DETACH frame with the error immediately after.
 		fr := frames.PerformAttach{
 			Name:   "Y-dfQa6Qdr3yhJmmsE5boDHNMYLDQugm_MKf4ZzwwUGObvmKiSBa_g",
-			Role:   true,
+			Role:   encoding.RoleReceiver,
 			Source: nil,
 			Target: nil,
 		}
@@ -44,7 +44,7 @@ func TestPerformAttach(t *testing.T) {
 
 		fr = frames.PerformAttach{
 			Name:   "Y-dfQa6Qdr3yhJmmsE5boDHNMYLDQugm_MKf4ZzwwUGObvmKiSBa_g",
-			Role:   false,
+			Role:   encoding.RoleSender,
 			Source: nil,
 			Target: nil,
 		}

--- a/internal/proto/frames/bodies_test.go
+++ b/internal/proto/frames/bodies_test.go
@@ -9,20 +9,47 @@ import (
 )
 
 func TestPerformAttach(t *testing.T) {
-	fr := frames.PerformAttach{
-		Role:   encoding.RoleSender,
-		Source: &frames.Source{Address: "source-address"},
-		Target: &frames.Target{Address: "target-address"},
-	}
+	t.Run("Basic ATTACH frames", func(t *testing.T) {
+		fr := frames.PerformAttach{
+			Role:   encoding.RoleSender,
+			Source: &frames.Source{Address: "source-address"},
+			Target: &frames.Target{Address: "target-address"},
+		}
 
-	require.Equal(t, "target-address", fr.Address(true))
-	require.Equal(t, "source-address", fr.Address(false))
+		require.Equal(t, "target-address", fr.Address(true))
+		require.Equal(t, "source-address", fr.Address(false))
 
-	fr = frames.PerformAttach{
-		Role:   encoding.RoleReceiver,
-		Source: &frames.Source{Address: "source-address"},
-		Target: &frames.Target{Address: "target-address"},
-	}
-	require.Equal(t, "source-address", fr.Address(true))
-	require.Equal(t, "target-address", fr.Address(false))
+		fr = frames.PerformAttach{
+			Role:   encoding.RoleReceiver,
+			Source: &frames.Source{Address: "source-address"},
+			Target: &frames.Target{Address: "target-address"},
+		}
+		require.Equal(t, "source-address", fr.Address(true))
+		require.Equal(t, "target-address", fr.Address(false))
+	})
+
+	t.Run("ATTACH without rights", func(t *testing.T) {
+		// it's also possible for both Source and Target to be nil, in cases where
+		// you didn't actually have rights to ATTACH. This'll come back as an ATTACH frame
+		// with those values 'nil', and a DETACH frame with the error immediately after.
+		fr := frames.PerformAttach{
+			Name:   "Y-dfQa6Qdr3yhJmmsE5boDHNMYLDQugm_MKf4ZzwwUGObvmKiSBa_g",
+			Role:   true,
+			Source: nil,
+			Target: nil,
+		}
+
+		require.Equal(t, "", fr.Address(true))
+		require.Equal(t, "", fr.Address(false))
+
+		fr = frames.PerformAttach{
+			Name:   "Y-dfQa6Qdr3yhJmmsE5boDHNMYLDQugm_MKf4ZzwwUGObvmKiSBa_g",
+			Role:   false,
+			Source: nil,
+			Target: nil,
+		}
+
+		require.Equal(t, "", fr.Address(true))
+		require.Equal(t, "", fr.Address(false))
+	})
 }


### PR DESCRIPTION
This happens when you connect with an identity that doesn't have proper permissions - the Source and Target are nil, and then you get a DETACH frame immediately with an error.