### PR TITLE
Add a "delay after number of messages" flag to the transfer_delay fault injector

### DIFF
--- a/cmd/faultinjector/commands.go
+++ b/cmd/faultinjector/commands.go
@@ -127,17 +127,19 @@ func newDetachAfterTransferCommand(ctx context.Context) *cobra.Command {
 
 func newSlowTransferFrames(ctx context.Context) *cobra.Command {
 	var delay *time.Duration
+	var after *int
 
 	cmd := &cobra.Command{
 		Use:   "transfer_delay",
 		Short: "Slows down TRANSFER frames",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			injector := faultinjectors.NewSlowTransfersInjector(*delay)
+			injector := faultinjectors.NewSlowTransfersInjector(*delay, *after)
 			return runFaultInjector(ctx, cmd, injector.Callback)
 		},
 	}
 
 	delay = cmd.Flags().Duration("delay", 10*time.Second, "Amount of delay to introduce before each TRANSFER frame")
+	after = cmd.Flags().Int("after", 0, "Start delaying after this number of TRANSFER frames have been sent")
 	return cmd
 }
 

--- a/internal/faultinjectors/mirroring_test.go
+++ b/internal/faultinjectors/mirroring_test.go
@@ -298,8 +298,8 @@ func oopsAllAttachFrameNames(allFrames []*frames.Frame) []string {
 }
 
 // LoadStateMap loads up some pre-recorded ATTACH frames int our statemap:
-// - a receiver, with local channel/handle: 200/200, remote 0/0
-// - a sender, with local channel/handle 300/300, remote 1001/1002
+//   - a receiver, with local channel/handle: 200/200, remote 0/0
+//   - a sender, with local channel/handle 300/300, remote 1001/1002
 func loadStateMap(t *testing.T) *proto.StateMap {
 	sm := proto.NewStateMap()
 
@@ -359,6 +359,9 @@ func loadStateMap(t *testing.T) *proto.StateMap {
 	return sm
 }
 
+// loadCBSStateMap loads a map with $cbs frames.
+//   - Ours: channel 200, handle 201
+//   - Theirs: channel 0, handle 1
 func loadCBSStateMap(t *testing.T) *proto.StateMap {
 	sm := proto.NewStateMap()
 

--- a/internal/faultinjectors/multi_transfer_injector_test.go
+++ b/internal/faultinjectors/multi_transfer_injector_test.go
@@ -39,21 +39,24 @@ func TestMultiTransferInjector(t *testing.T) {
 	// 	Validate the result
 	require.Len(t, resultFrames, len(transferBody.Payload)) // Each byte should result in a separate frame
 
+	// now, take all the individual frames and combine them, and unmarshal it.
+	var fullPayload []byte
+
 	for i, frame := range resultFrames {
 		require.Equal(t, faultinjectors.MetaFrameActionAdded, frame.Action)
 		require.NotNil(t, frame.Frame)
 
 		// Validate the payload of each frame
-		clonedTransferFrame, ok := frame.Frame.Body.(*frames.PerformTransfer)
+		splitTransferFrame, ok := frame.Frame.Body.(*frames.PerformTransfer)
 		require.True(t, ok)
-		require.Equal(t, []byte{transferBody.Payload[i]}, clonedTransferFrame.Payload)
+		require.Equal(t, []byte{transferBody.Payload[i]}, splitTransferFrame.Payload)
 
 		// Validate the "More" flag
 		expectedMore := i != len(transferBody.Payload)-1
-		require.Equal(t, expectedMore, clonedTransferFrame.More)
+		require.Equal(t, expectedMore, splitTransferFrame.More)
+
+		fullPayload = append(fullPayload, splitTransferFrame.Payload...)
 	}
 
-	// now, take all the individual frames and combine them, and unmarshal it.
-	var fullPayload []byte
-
+	require.Equal(t, "Hello world!", string(fullPayload))
 }

--- a/internal/faultinjectors/multi_transfer_injector_test.go
+++ b/internal/faultinjectors/multi_transfer_injector_test.go
@@ -15,38 +15,6 @@ func TestMultiTransferInjector(t *testing.T) {
 	injector := faultinjectors.NewMultiTransferInjector()
 	var stateMap = &proto.StateMap{}
 	// Pass incoming and outgoing ATTACH frames to populate the state map
-	var incomingAttachFrame = &frames.Frame{
-		Header: frames.Header{
-			Channel: 0,
-		},
-		Body: &frames.PerformAttach{
-			Role:   false,
-			Handle: 2,
-		},
-	}
-	params := faultinjectors.MirrorCallbackParams{
-		StateMap: stateMap,
-		Frame:    incomingAttachFrame,
-		Out:      false,
-	}
-	resultFrames, err := injector.Callback(context.Background(), params)
-	require.NoError(t, err)
-	var outgoingAttachFrame = &frames.Frame{
-		Header: frames.Header{
-			Channel: 1,
-		},
-		Body: &frames.PerformAttach{
-			Role:   true,
-			Handle: 3,
-		},
-	}
-	params = faultinjectors.MirrorCallbackParams{
-		StateMap: stateMap,
-		Frame:    outgoingAttachFrame,
-		Out:      true,
-	}
-	resultFrames, err = injector.Callback(context.Background(), params)
-	require.NoError(t, err)
 
 	// Create a PerformTransfer frame
 	var transferBody = &frames.PerformTransfer{
@@ -60,13 +28,14 @@ func TestMultiTransferInjector(t *testing.T) {
 			Channel: 0,
 		},
 	}
-	params = faultinjectors.MirrorCallbackParams{
+	params := faultinjectors.MirrorCallbackParams{
 		StateMap: stateMap,
 		Frame:    transferFrame,
 		Out:      false,
 	}
-	resultFrames, err = injector.Callback(context.Background(), params)
+	resultFrames, err := injector.Callback(context.Background(), params)
 	require.NoError(t, err)
+
 	// 	Validate the result
 	require.Len(t, resultFrames, len(transferBody.Payload)) // Each byte should result in a separate frame
 
@@ -83,4 +52,8 @@ func TestMultiTransferInjector(t *testing.T) {
 		expectedMore := i != len(transferBody.Payload)-1
 		require.Equal(t, expectedMore, clonedTransferFrame.More)
 	}
+
+	// now, take all the individual frames and combine them, and unmarshal it.
+	var fullPayload []byte
+
 }

--- a/internal/faultinjectors/slow_transfers_injector_test.go
+++ b/internal/faultinjectors/slow_transfers_injector_test.go
@@ -1,0 +1,110 @@
+package faultinjectors
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/richardpark-msft/amqpfaultinjector/internal/proto"
+	"github.com/richardpark-msft/amqpfaultinjector/internal/proto/frames"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSlowTransfersInjector(t *testing.T) {
+	const after = 3
+	sfi := NewSlowTransfersInjector(time.Second, after)
+
+	sm := loadStateMap(t)
+
+	params := MirrorCallbackParams{
+		Out: false,
+		Frame: &frames.Frame{
+			Header: frames.Header{Channel: 0},
+			Body: &frames.PerformTransfer{
+				Handle: 0,
+			},
+		},
+		StateMap: sm,
+	}
+
+	for i := range after {
+		now := time.Now()
+		values, err := sfi.Callback(context.Background(), params)
+		duration := time.Since(now)
+
+		require.NoError(t, err, "Iteration: %d", i)
+		require.NotEmpty(t, values, "Iteration: %d", i)
+		// a little wiggle room here on the sleep, but this should prove that we're not
+		// doing the TRANSFER frame pause.
+		require.Greater(t, 500*time.Millisecond, duration, "Iteration: %d", i)
+		require.Equal(t, i+1, sfi.numTransfers)
+	}
+
+	for i := 0; i < 2; i++ {
+		now := time.Now()
+
+		values, err := sfi.Callback(context.Background(), params)
+		require.NoError(t, err)
+		require.NotEmpty(t, values)
+
+		require.LessOrEqual(t, time.Second, time.Since(now))
+	}
+}
+
+func TestSlowTransfersInjector_Passthrough(t *testing.T) {
+	t.Run("outbound frames ignored", func(t *testing.T) {
+		sfi := NewSlowTransfersInjector(time.Second, 1)
+
+		sm := proto.NewStateMap()
+		params := MirrorCallbackParams{Out: true, Frame: &frames.Frame{}, StateMap: sm}
+
+		values, err := sfi.Callback(context.Background(), params)
+		require.NoError(t, err)
+		require.Equal(t, MetaFrameActionPassthrough, values[0].Action)
+		require.Same(t, params.Frame, values[0].Frame)
+		require.Equal(t, 0, sfi.numTransfers)
+	})
+
+	t.Run("$cbs ignored", func(t *testing.T) {
+		sfi := NewSlowTransfersInjector(time.Second, 1)
+
+		sm := loadCBSStateMap(t)
+
+		fr := &frames.Frame{
+			Header: frames.Header{Channel: 0},
+			Body: &frames.PerformTransfer{
+				Handle: 1,
+			},
+		}
+
+		params := MirrorCallbackParams{Out: false, Frame: fr, StateMap: sm}
+
+		values, err := sfi.Callback(context.Background(), params)
+		require.NoError(t, err)
+		require.Equal(t, MetaFrameActionPassthrough, values[0].Action)
+		require.Same(t, params.Frame, values[0].Frame)
+		require.Equal(t, 0, sfi.numTransfers)
+	})
+
+	t.Run("non-transfer frames", func(t *testing.T) {
+		sfi := NewSlowTransfersInjector(time.Second, 1)
+
+		sm := loadStateMap(t)
+
+		fr := &frames.Frame{
+			Header: frames.Header{Channel: 0},
+			Body: &frames.PerformFlow{
+				Handle: to.Ptr[uint32](0),
+			},
+		}
+
+		params := MirrorCallbackParams{Out: false, Frame: fr, StateMap: sm}
+
+		values, err := sfi.Callback(context.Background(), params)
+		require.NoError(t, err)
+		require.Equal(t, MetaFrameActionPassthrough, values[0].Action)
+		require.Same(t, params.Frame, values[0].Frame)
+		require.Equal(t, 0, sfi.numTransfers)
+	})
+}


### PR DESCRIPTION
This makes it really easy to test any batching algorithms for receiving on the client side - now you can ensure that exactly 'x' number of messages make it in before the delay, allowing you to test your client timeouts in a deterministic way.